### PR TITLE
Made some changes to work on python 3.8 (not tested versions below)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ workdir
 build
 __pycache__
 *.egg*
+**/.DS_Store
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 keywords = ["galaxies"]
 license = {file = "LICENSE.txt"}
 description = "Make galaxy cubes (X, Y, Lambda) with S-PLUS data."
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ description = "Make galaxy cubes (X, Y, Lambda) with S-PLUS data."
 requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 4 - Beta",
-    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.8",
     "Topic :: Scientific/Engineering :: Astronomy",
 ]
 dependencies = [

--- a/src/scubes/__init__.py
+++ b/src/scubes/__init__.py
@@ -3,9 +3,11 @@ from importlib.metadata import version, metadata
 
 from . import data
 
+import os
+
 scubes_meta = metadata('s-cubes')
 __author__ = scubes_meta['Author-email']
 __version__ = version('s-cubes')
 
-__zp_cat__ = str(resources.files(data) / 'iDR4_zero-points.csv')
-__zpcorr_path__ = str(resources.files(data) / 'zpcorr_iDR4')
+__zp_cat__ = os.path.join(data.__path__[0], 'iDR4_zero-points.csv')
+__zpcorr_path__ = os.path.join(data.__path__[0], 'zpcorr_iDR4')

--- a/src/scubes/utilities/sextractor.py
+++ b/src/scubes/utilities/sextractor.py
@@ -4,11 +4,13 @@ from regions import PixCoord, CirclePixelRegion
 
 from .data import sex
 
-__data_files__ = resources.files(sex)
+import os
 
-SEX_TOPHAT_FILTER = str(__data_files__ / 'tophat_3.0_3x3.conv') 
-SEX_DEFAULT_FILTER = str(__data_files__ / 'default.conv') 
-SEX_DEFAULT_STARNNW = str(__data_files__ / 'default.nnw') 
+__data_files__ = sex.__path__[0]
+
+SEX_TOPHAT_FILTER = os.path.join(__data_files__, 'tophat_3.0_3x3.conv') 
+SEX_DEFAULT_FILTER = os.path.join(__data_files__, 'default.conv') 
+SEX_DEFAULT_STARNNW = os.path.join(__data_files__, 'default.nnw') 
 
 from sewpy import SEW
 from os.path import join


### PR DESCRIPTION
Made some changes to work on python 3.8 

Changed 
```python
resources.files()
```

to:
```
os.path.join
```

It seems that python3.9 below do not accept a namespace as parameter on resource.files, only strings. 